### PR TITLE
Update runtime to 50

### DIFF
--- a/dev.bragefuglseth.Fretboard.json
+++ b/dev.bragefuglseth.Fretboard.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "dev.bragefuglseth.Fretboard",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "48",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -16,30 +16,7 @@
     "build-options" : {
         "append-path" : "/usr/lib/sdk/rust-stable/bin"
     },
-    "cleanup" : [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
     "modules" : [
-    	{
-	  "name": "blueprint-compiler",
-	  "buildsystem": "meson",
-	  "cleanup": ["*"],
-	  "sources": [
-	    {
-	      "type": "git",
-	      "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-	      "tag": "v0.16.0"
-	    }
-	  ]
-	},
         {
             "name" : "fretboard",
             "builddir" : true,


### PR DESCRIPTION
- Update runtime to 50
- Drop blueprint-compiler module, which is already provided by the runtime.
- Drop ineffective cleanup commands.